### PR TITLE
Allow ability to set security context for postgres deployment.

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1771,6 +1771,10 @@ spec:
               session_cookie_secure:
                 description: Set session cookie secure mode for web
                 type: string
+              postgres_security_context_settings:
+                description: Key/values that will be set under the pod-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true                
               receptor_log_level:
                 description: Set log level of receptor service
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -55,6 +55,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: PostgreSQL Security Context Settings
+        path: postgres.security_context_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden        
       - displayName: PostgreSQL Image
         path: postgres_image
         x-descriptors:

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -51,6 +51,12 @@ spec:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
+{% if postgres.security_context_settings is defined %}
+          securityContext:
+{% if postgres.security_context_settings|length %}
+      {{ postgres.security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
+{% endif %}          
 {% if postgres_extra_args %}
           args: {{ postgres_extra_args }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Allow ability to set security context for postgres containers during deployment.
Example it will allow users to deploy postgres as Non Root.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
Issue #1451  will be addressed hopefully
